### PR TITLE
Improve publish wiki workflow as it's outdated

### DIFF
--- a/.github/workflows/publish_wiki.yml
+++ b/.github/workflows/publish_wiki.yml
@@ -1,4 +1,5 @@
-# For setup instruction, refer to https://github.com/nimblehq/github-actions-workflows/blob/main/.github/workflows/publish_wiki.yml
+# Configuration details can be found here:
+# https://github.com/nimblehq/publish-github-wiki-action
 name: Publish Wiki
 
 on:
@@ -13,11 +14,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  publish:
+  publish_wiki:
     name: Publish Wiki
-    uses: nimblehq/github-actions-workflows/.github/workflows/publish_wiki.yml@0.1.0
-    with:
-      USER_NAME: github-wiki-workflow
-      USER_EMAIL: ${{ secrets.GH_EMAIL }}
-    secrets:
-      USER_TOKEN: ${{ secrets.GH_TOKEN }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Publish Github Wiki
+        uses: nimblehq/publish-github-wiki-action@v1.0
+        with:
+          user_name: bot-nimble
+          user_email: ${{ secrets.GH_EMAIL }}
+          user_access_token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Related to this issue: https://github.com/nimblehq/git-template/issues/37

## What happened 👀

- Updated the publish_wiki workflow.

## Insight 📝

Our wiki workflow has been updated and moved to a separate [repository](https://github.com/nimblehq/publish-github-wiki-action). But the `git-template` continued to use the old version in its configuration until last month

## Proof Of Work 📹

I followed this pull request: https://github.com/nimblehq/git-template/pull/38
